### PR TITLE
Fix EntityListeners for SDKHooks and SDKTools Gamedata for PVKII

### DIFF
--- a/gamedata/sdkhooks.games/game.pvkii.txt
+++ b/gamedata/sdkhooks.games/game.pvkii.txt
@@ -5,6 +5,11 @@
 	{
 		"Offsets"
 		{
+			"EntityListeners"
+			{
+				"windows"	"262180"
+				"linux"		"262180"
+			}
 			"Blocked"
 			{
 				"windows"	"104"


### PR DESCRIPTION
Fix EntityListeners for SDKHooks and SDKTools Gamedata for PVKII (Increased edict limit to 8,192 since 0.5.1.2)

It fix https://github.com/alliedmodders/sourcemod/issues/2200